### PR TITLE
Add VPN setting and sensors

### DIFF
--- a/pysmlight/const.py
+++ b/pysmlight/const.py
@@ -88,6 +88,7 @@ class Settings(Enum):
     DISABLE_LEDS = (Pages.API2_PAGE_SETTINGS_LED, "disableLeds")
     NIGHT_MODE = (Pages.API2_PAGE_SETTINGS_LED, "nightMode")
     ZB_AUTOUPDATE = (Pages.API2_PAGE_SETTINGS_OTA, "enabled")
+    ENABLE_VPN = (Pages.API2_PAGE_VPN, "enabled")
 
 
 class WifiStatus(Enum):

--- a/pysmlight/models.py
+++ b/pysmlight/models.py
@@ -63,11 +63,13 @@ class Sensors(DataClassDictMixin):
     ethernet: bool = False
     wifi_connected: bool = False
     wifi_status: int | str | None = None  # enum (off, client, AP etc)
+    vpn_status: bool = False
 
     # toggle states:
     disable_leds: bool | None = None
     night_mode: bool | None = None
     auto_zigbee: bool | None = None
+    vpn_enabled: bool | None = None
 
     def __post_init__(self):
         if self.socket_uptime is not None and self.socket_uptime <= 0:


### PR DESCRIPTION
Add support for Wireguard VPN to data models. This will allow for:
* VPN status, binary sensor
* VPN enabled, switch

This feature requires SMLIGHT core firmware 2.5.3 or later.