### PR TITLE
Allow SSE library to handle reconnect.

### DIFF
--- a/pysmlight/sse.py
+++ b/pysmlight/sse.py
@@ -36,7 +36,7 @@ class sseClient:
                 async for event in event_source:
                     _LOGGER.debug(event)
                     await self.message_handler(event)
-            except aiohttp.ClientConnectionError:
+            except ConnectionError:
                 _LOGGER.debug("Client Connection error")
             else:
                 _LOGGER.debug("Connection closed cleanly")


### PR DESCRIPTION
Catching `ClientConnectionError` was bypassing the builtin retry connection logic in aiohttp_sse_client lib. 