### PR TITLE
Fix firmware selection for Zigbee firmware

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 __pycache__/
 dist/
-pysmlight/secrets.py
+.venv/
+.coverage
+old/
+poetry.lock

--- a/pysmlight/models.py
+++ b/pysmlight/models.py
@@ -14,7 +14,7 @@ class Firmware(DataClassDictMixin):
     link: str | None = None
     ver: str | None = None
     dev: bool = False
-    prod: bool = True
+    prod: bool = False
     baud: int | None = None
 
     def __post_init__(self):

--- a/pysmlight/web.py
+++ b/pysmlight/web.py
@@ -189,7 +189,7 @@ class Api2(webClient):
             item = Firmware.from_dict(d)
             if not item.dev or channel == "dev":
                 item.set_mode(fw_type)
-                if fw_type == "ESP":
+                if item.notes:
                     item.notes = self.format_notes(item)
                 fw.append(item)
         return fw
@@ -197,13 +197,20 @@ class Api2(webClient):
     def format_notes(self, firmware: Firmware) -> str | None:
         """Format release notes for esp firmware"""
         if firmware and firmware.notes:
-            items = re.split("\r\n|(?<!\r)\n", firmware.notes)
+            items = (
+                re.split("\r\n|(?<!\r)\n", firmware.notes)
+                if firmware.mode == "ESP"
+                else [firmware.notes]
+            )
             notes = ""
             for i, v in enumerate(items):
                 if i and v and not v.startswith("-"):
                     notes += f"* {v}\n"
                 else:
                     notes += f"{v}\n\n"
+
+            if firmware.dev and firmware.mode == "ZB":
+                notes = "Dev firmware.\n\n" + notes
             return notes
         return None
 

--- a/tests/test_firmware.py
+++ b/tests/test_firmware.py
@@ -107,15 +107,13 @@ async def test_info_get_firmware_zb(aresponses: ResponsesMockServer) -> None:
     )
     async with ClientSession() as session:
         client = Api2(host, session=session)
-        fw = await client.get_firmware_version(
-            "release", device="SLZB-06M", mode="zigbee"
-        )
+        fw = await client.get_firmware_version("dev", device="SLZB-06M", mode="zigbee")
         assert fw
         assert len(fw) == 5
         firmware = fw[0]
         assert firmware.link
         assert firmware.mode == "ZB"
-        assert firmware.dev is False
+        assert firmware.dev is True
         assert firmware.ver == "20240510"
         assert firmware.type == 0
 


### PR DESCRIPTION
Fix handling of dev channel settings for Zigbee firmware.
Also tag as dev firmware in release notes, since Zigbee builds dont include 'dev' in version field