### PR TITLE
Fix handle settings when changes field is missing from event data

### DIFF
--- a/pysmlight/sse.py
+++ b/pysmlight/sse.py
@@ -99,21 +99,22 @@ class sseClient:
             return
 
         changes = data.pop("changes", None)
-        for setting in changes:
-            base = data.copy()
-            match_cb = next(
-                (
-                    cb
-                    for k, cb in self.settings_cb.items()
-                    if (page, setting) == k.value
-                ),
-                None,
-            )
+        if changes is not None:
+            for setting in changes:
+                base = data.copy()
+                match_cb = next(
+                    (
+                        cb
+                        for k, cb in self.settings_cb.items()
+                        if (page, setting) == k.value
+                    ),
+                    None,
+                )
 
-            if match_cb:
-                base["setting"] = {setting: changes[setting]}
-                result = SettingsEvent.from_dict(base)
-                match_cb(result)
+                if match_cb:
+                    base["setting"] = {setting: changes[setting]}
+                    result = SettingsEvent.from_dict(base)
+                    match_cb(result)
 
     def register_settings_cb(
         self, setting: Settings, cb: Callable


### PR DESCRIPTION
It is possible for settings event to not contain the changes field. Fix the case where it is missing.

Fixes this error
```
2024-10-07 11:04:55.666 ERROR (MainThread) [homeassistant] Error doing job: Task exception was never retrieved (None)
Traceback (most recent call last):
  File "/usr/local/lib/python3.12/site-packages/pysmlight/sse.py", line 52, in client
    await self.sse_stream()
  File "/usr/local/lib/python3.12/site-packages/pysmlight/sse.py", line 64, in sse_stream
    await self._message_handler(event)
  File "/usr/local/lib/python3.12/site-packages/pysmlight/sse.py", line 73, in _message_handler
    self.callbacks.get(event_type, lambda x: None)(event)
  File "/usr/local/lib/python3.12/site-packages/pysmlight/sse.py", line 102, in _handle_settings
    for setting in changes:
TypeError: 'NoneType' object is not iterable
```