### PR TITLE
Fix failing redirects to new SSE server

### DIFF
--- a/pysmlight/web.py
+++ b/pysmlight/web.py
@@ -8,6 +8,7 @@ import urllib.parse
 
 from aiohttp import BasicAuth, ClientSession
 from aiohttp.client_exceptions import ClientConnectionError
+from packaging.version import Version
 
 from .const import FW_URL, PARAM_LIST, Actions, Commands, Devices, Events, Pages
 from .exceptions import SmlightAuthError, SmlightConnectionError
@@ -241,6 +242,8 @@ class Api2(webClient):
             return await self.get_info_old()
 
         data = json.loads(res)
+        if self.sse.sw_version is None:
+            self.sse.sw_version = Version(data["Info"]["sw_version"])
         return Info.from_dict(data["Info"])
 
     async def get_sensors(self) -> Sensors:

--- a/tests/test_firmware.py
+++ b/tests/test_firmware.py
@@ -96,8 +96,8 @@ async def test_format_release_notes() -> None:
 
 async def test_info_get_firmware_zb(aresponses: ResponsesMockServer) -> None:
     aresponses.add(
-        "smlight.tech",
-        "/flasher/firmware/bin/slzb06x/ota.php",
+        "updates.smlight.tech",
+        "/services/api/slzb-06x-ota.php",
         "GET",
         aresponses.Response(
             status=200,
@@ -120,8 +120,8 @@ async def test_info_get_firmware_zb(aresponses: ResponsesMockServer) -> None:
 
 async def test_info_get_firmware_esp(aresponses: ResponsesMockServer) -> None:
     aresponses.add(
-        "smlight.tech",
-        "/flasher/firmware/bin/slzb06x/ota.php",
+        "updates.smlight.tech",
+        "/services/api/slzb-06x-ota.php",
         "GET",
         aresponses.Response(
             status=200,


### PR DESCRIPTION
SSE server has been moved to `http://<host>:81`, the redirect that was implement for backwards compatibility fails even authentication is enabled on SLZB device.

Directly use the new SSE server location.

Fixes: https://github.com/home-assistant/core/issues/135870