### PR TITLE
Add support for new radios key

### DIFF
--- a/pysmlight/models.py
+++ b/pysmlight/models.py
@@ -28,6 +28,18 @@ class Firmware(DataClassDictMixin):
 
 
 @dataclass
+class Radio(DataClassDictMixin):
+    chip_index: int | None = None
+    zb_channel: int | None = None
+    zb_flash_size: int | None = None
+    zb_hw: str | None = None
+    zb_ram_size: int | None = None
+    zb_version: str | None = None
+    zb_type: int | None = None  # enum (coordinator, router, thread)
+    radioModes: list[bool] | None = None
+
+
+@dataclass
 class Info(DataClassDictMixin):
     coord_mode: int | None = None  # Enum
     device_ip: str | None = None
@@ -40,6 +52,7 @@ class Info(DataClassDictMixin):
     ram_total: int | None = None
     sw_version: str | None = None
     wifi_mode: int | None = None  # enum (off, client, AP etc)
+    radios: list[Radio] | None = None
     zb_channel: int | None = None
     zb_flash_size: int | None = None
     zb_hw: str | None = None
@@ -65,6 +78,10 @@ class Info(DataClassDictMixin):
         if self.model is not None:
             self.model = self.model.replace("P", "p")
         self.zb_version = str(self.zb_version)
+
+        if self.radios is not None:
+            for r in self.radios:
+                r.zb_version = str(r.zb_version)
 
 
 @dataclass

--- a/tests/fixtures/slzb-06-info-radios.json
+++ b/tests/fixtures/slzb-06-info-radios.json
@@ -1,0 +1,42 @@
+{
+    "Info": {
+      "wifi_mode": 0,
+      "ram_total": 300,
+      "fs_total": 3456,
+      "zb_ram_size": 96,
+      "zb_flash_size": 768,
+      "coord_mode": 0,
+      "device_ip": "192.168.1.62",
+      "fw_channel": "dev",
+      "hostname": "SLZB-MR1",
+      "MAC": "DD:88:FC:AA:EE:FF",
+      "model": "SLZB-MR1",
+      "sw_version": "v2.7.1",
+      "zb_hw": "EFR32MG21",
+      "zb_version": 20240510,
+      "zb_type": 0,
+      "zb_channel": 1,
+      "radios": [
+        {
+          "chip_index": 0,
+          "zb_hw": "EFR32MG21",
+          "zb_version": 20240510,
+          "zb_type": 0,
+          "zb_channel": 1,
+          "zb_ram_size": 96,
+          "zb_flash_size": 768,
+          "radioModes": [true, true, true, false, false]
+        },
+        {
+          "chip_index": 1,
+          "zb_hw": "CC2652P7",
+          "zb_version": 20240716,
+          "zb_type": 0,
+          "zb_channel": 1,
+          "zb_ram_size": 152,
+          "zb_flash_size": 704,
+          "radioModes": [true, true, true, false, false]
+        }
+      ]
+    }
+  }

--- a/tests/test_info.py
+++ b/tests/test_info.py
@@ -49,6 +49,56 @@ async def test_info_device_info(aresponses: ResponsesMockServer) -> None:
         assert info.zb_type == 0
         assert info.legacy_api == 0
         assert info.hostname == "SLZB-06P10"
+        assert info.radios is None
+
+
+async def test_info_device_mr_info(aresponses: ResponsesMockServer) -> None:
+    """Test getting SLZB device information for multi radios."""
+    aresponses.add(
+        host,
+        "/ha_info",
+        "GET",
+        aresponses.Response(
+            status=200,
+            headers={"Content-Type": "application/json"},
+            text=load_fixture("slzb-06-info-radios.json"),
+        ),
+    )
+    async with ClientSession() as session:
+        client = Api2(host, session=session)
+        info: Info = await client.get_info()
+        assert info
+
+        assert info.wifi_mode == 0
+        assert info.ram_total == 300
+        assert info.fs_total == 3456
+        assert info.coord_mode == 0
+        assert info.device_ip == "192.168.1.62"
+        assert info.fw_channel == "dev"
+        assert info.MAC == "DD:88:FC:AA:EE:FF"
+        assert info.model == "SLZB-MR1"
+        assert info.sw_version == "v2.7.1"
+        assert info.legacy_api == 0
+        assert info.hostname == "SLZB-MR1"
+
+        assert info.radios is not None
+        assert len(info.radios) == 2
+        assert info.radios[0].chip_index == 0
+        assert info.radios[0].zb_channel == 1
+        assert info.radios[0].zb_flash_size == 768
+        assert info.radios[0].zb_hw == "EFR32MG21"
+        assert info.radios[0].zb_ram_size == 96
+        assert info.radios[0].zb_type == 0
+        assert info.radios[0].zb_version == "20240510"
+        assert info.radios[0].radioModes == [True, True, True, False, False]
+        assert info.radios[1].chip_index == 1
+        assert info.radios[1].zb_channel == 1
+        assert info.radios[1].zb_flash_size == 704
+        assert info.radios[1].zb_hw == "CC2652P7"
+        assert info.radios[1].zb_ram_size == 152
+        assert info.radios[1].zb_type == 0
+        assert info.radios[1].zb_version == "20240716"
+        assert info.radios[1].radioModes == [True, True, True, False, False]
 
 
 async def test_info_get_auth_fail(aresponses: ResponsesMockServer) -> None:


### PR DESCRIPTION
the `ha_info` endpoint has added a radios key to encapsulate radio metadata where multiple radios exist.
Add this as a dataclass.