### PR TITLE
Fix invalid dev version values

### DIFF
--- a/pysmlight/models.py
+++ b/pysmlight/models.py
@@ -92,6 +92,8 @@ class Info(DataClassDictMixin):
     def __post_init__(self) -> None:
         if self.model is not None:
             self.model = self.model.replace("P", "p")
+            self.model = self.model.replace("MG", "Mg")
+
         self.check_zb_version()
 
         # Factory firmware may have invalid .plus suffix, convert to valid version

--- a/pysmlight/models.py
+++ b/pysmlight/models.py
@@ -95,12 +95,15 @@ class Info(DataClassDictMixin):
         self.check_zb_version()
 
         # Factory firmware may have invalid .plus suffix, convert to valid version
-        if self.sw_version and "plus" in self.sw_version:
-            self.sw_version = re.sub(
-                r"\.plus(\d*)$",
-                lambda m: f".{m.group(1) if m.group(1) else '1'}",
-                self.sw_version,
-            )
+        if self.sw_version:
+            if "plus" in self.sw_version:
+                self.sw_version = re.sub(
+                    r"\.plus(\d*)$",
+                    lambda m: f".{m.group(1) if m.group(1) else '1'}",
+                    self.sw_version,
+                )
+            elif self.sw_version.endswith(".dev"):
+                self.sw_version = f"{self.sw_version}0"
 
         if self.radios is None:
             # construct radio object for backward compatibility (v2.5.0)

--- a/pysmlight/web.py
+++ b/pysmlight/web.py
@@ -253,7 +253,10 @@ class Api2(webClient):
             return await self.get_info_old()
 
         data = json.loads(res)
-        core_version = AwesomeVersion(data["Info"]["sw_version"])
+
+        info = Info.from_dict(data["Info"])
+        core_version = AwesomeVersion(info.sw_version)
+
         if self.core_version is None:
             self.core_version = core_version
         if self.sse.sw_version is None:

--- a/tests/test_info.py
+++ b/tests/test_info.py
@@ -273,9 +273,14 @@ async def test_info_legacy_info2(aresponses: ResponsesMockServer) -> None:
         assert info.legacy_api == 2
 
 
-async def test_info_plus_version() -> None:
-    """Test conversion of factory firmware that may have .plus suffix."""
+async def test_info_invalid_versions() -> None:
+    """Test conversion of invalid firmware versions (per awesomeVersion)
+
+    factory firmware that may have .plus suffix
+    development firmware that may have .dev suffix."""
     info = Info(sw_version="v2.3.6.plus")
     assert info.sw_version == "v2.3.6.1"
     info = Info(sw_version="v2.3.6.plus2")
     assert info.sw_version == "v2.3.6.2"
+    info = Info(sw_version="v2.8.0.dev")
+    assert info.sw_version == "v2.8.0.dev0"


### PR DESCRIPTION
AwesomeVersion cannot pass development versions like "2.8.0.dev". Convert this to a valid version "2.8.0.dev0"