### PR TITLE
Fix invalid development version values (#31)

### DIFF
--- a/pysmlight/models.py
+++ b/pysmlight/models.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+import re
 
 from mashumaro import DataClassDictMixin
 
@@ -64,7 +65,20 @@ class Info(DataClassDictMixin):
     def __post_init__(self) -> None:
         if self.model is not None:
             self.model = self.model.replace("P", "p")
+            self.model = self.model.replace("MG", "Mg")
+
         self.zb_version = str(self.zb_version)
+
+        # Factory firmware may have invalid .plus suffix, convert to valid version
+        if self.sw_version:
+            if "plus" in self.sw_version:
+                self.sw_version = re.sub(
+                    r"\.plus(\d*)$",
+                    lambda m: f".{m.group(1) if m.group(1) else '1'}",
+                    self.sw_version,
+                )
+            elif self.sw_version.endswith(".dev"):
+                self.sw_version = f"{self.sw_version}0"
 
 
 @dataclass

--- a/tests/test_info.py
+++ b/tests/test_info.py
@@ -204,3 +204,16 @@ async def test_info_legacy_info2(aresponses: ResponsesMockServer) -> None:
         assert info.model == "SLZB-06"
         assert info.sw_version == "0.9.9"
         assert info.legacy_api == 2
+
+
+async def test_info_invalid_versions() -> None:
+    """Test conversion of invalid firmware versions (per awesomeVersion)
+
+    factory firmware that may have .plus suffix
+    development firmware that may have .dev suffix."""
+    info = Info(sw_version="v2.3.6.plus")
+    assert info.sw_version == "v2.3.6.1"
+    info = Info(sw_version="v2.3.6.plus2")
+    assert info.sw_version == "v2.3.6.2"
+    info = Info(sw_version="v2.8.0.dev")
+    assert info.sw_version == "v2.8.0.dev0"

--- a/tests/test_sse.py
+++ b/tests/test_sse.py
@@ -76,7 +76,7 @@ async def test_sse_stream(aresponses: ResponsesMockServer) -> None:
     log_message_handler = Mock()
     all_message_handler = Mock()
     settings_message_handler = Mock()
-    aresponses.add(host, "/events", "GET", mock_sse_stream)
+    aresponses.add(f"{host}:81", "/", "GET", mock_sse_stream)
     async with ClientSession() as session:
         client = Api2(host, session=session)
         unload.append(client.sse.register_callback(Events.LOG_STR, log_message_handler))


### PR DESCRIPTION
* Adjust invalid version if endswith ".dev"

* Adjust factory version if has "plus" suffix

* test conversion of .dev versions

* Correct case in model if needed

(backported  from commit 42604c129d68e644e664730b30d5f49859667c0c)