### PR TITLE
Remove upper constraint for awesomeversion

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ keywords = ["smlight", "slzb-06", "zigbee"]
 python = "^3.11"
 aiohttp = ">=3.9.3"
 aiohttp_sse_client2 = "^0.3.0"
-awesomeversion ="^24.6.0"
+awesomeversion =">=24.6.0"
 mashumaro = ">=3.10"
 
 [build-system]


### PR DESCRIPTION
`awesomeversion` uses `CalVer`. The constraint is currently blocking the update to `25.5.0` in Home Assistant.
A new release and bump in Home Assistant would be great.

Ref https://github.com/home-assistant/core/pull/146032